### PR TITLE
Plot Bloch path dynamically and extend band solver example

### DIFF
--- a/Band_Diagram_Solver/2D_Band_Diagram.py
+++ b/Band_Diagram_Solver/2D_Band_Diagram.py
@@ -1,160 +1,562 @@
+"""Two-dimensional FDFD band diagram solver.
+
+This module now exposes a :class:`BandDiagramSolver2D` that wraps the
+workflow for defining a periodic unit cell, sweeping Bloch wave vectors
+and extracting the photonic band structure.  The API mirrors the style of
+the other solvers in the repository – users can programmatically add
+objects to the Yee grid, request a path through the irreducible Brillouin
+zone and plot the resulting bands.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Iterable, Sequence
+
 import matplotlib.gridspec as gridspec
-import matplotlib.image as mpimg
 import matplotlib.pyplot as plt
 import numpy as np
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
 from scipy.sparse import diags
 from scipy.sparse.linalg import eigs
 
 from yee_derivative import yeeder2d
 
-# CRYSTAL PARAMETERS
-a = 1.0
+MaskLike = np.ndarray | Callable[[np.ndarray, np.ndarray], np.ndarray]
 
-# FDFD PARAMETERS
-Nx = 40
-Ny = Nx
-NBETA = 100
-NBANDS = 5
-wnmax = 0.6
 
-# CALCULATE OPTIMIZED GRID
-dx = a / Nx
-dy = a / Ny
+@dataclass
+class BandStructureResult:
+    """Container returned by :meth:`BandDiagramSolver2D.compute_band_structure`.
 
-# 2X GRID
-Nx2 = 2 * Nx
-dx2 = dx / 2
-Ny2 = 2 * Ny
-dy2 = dy / 2
+    Attributes
+    ----------
+    beta_path : np.ndarray
+        2×N array whose columns contain the Bloch wave-vector samples.
+    tick_positions : list[int]
+        Index locations that delimit the symmetry-point segments.
+    tick_labels : list[str]
+        Labels (Γ, X, …) associated with ``tick_positions``.
+    frequencies : dict[str, np.ndarray]
+        Dictionary keyed by polarisation ('TE' and/or 'TM').  Each entry is
+        an array of shape (num_bands, N) containing the normalised
+        frequencies ``a/λ``.
+    eigenvalues : dict[str, np.ndarray]
+        Un-normalised eigen-values (ω/c)² returned by the eigensolver for
+        each polarisation.
+    """
 
-# CALCULATE 2X MESHGRID
-xa2 = np.arange(1, Nx2 + 1) * dx2
-xa2 = xa2 - np.mean(xa2)
-ya2 = np.arange(1, Ny2 + 1) * dy2
-ya2 = ya2 - np.mean(ya2)
-X2, Y2 = np.meshgrid(xa2, ya2)
+    beta_path: np.ndarray
+    tick_positions: list[int]
+    tick_labels: list[str]
+    frequencies: dict[str, np.ndarray]
+    eigenvalues: dict[str, np.ndarray]
 
-# BUILD UNIT CELL
 
-r = 0.4 * a
-erhole = 1.0
-erfill = 10.2
-ER2 = (X2 ** 2 + Y2 ** 2) <= r ** 2
-ER2 = erfill + (erhole - erfill) * ER2
-UR2 = np.ones((Nx2, Ny2))
+class BandDiagramSolver2D:
+    """Finite-difference frequency-domain band diagram solver.
 
-# EXTRACT YEE GRID MATERIAL ARRAYS
-ERxx = ER2[1::2, ::2]
-ERyy = ER2[::2, 1::2]
-ERzz = ER2[::2, 1::2]
-URxx = UR2[1::2, ::2]
-URyy = UR2[::2, 1::2]
-URzz = UR2[::2, 1::2]
-# Constants
-a = 1  # Define 'a' as required for your specific problem
-NBETA = 100  # Define 'NBETA' as required
+    Parameters
+    ----------
+    a : float
+        Lattice constant of the (square) unit cell.
+    Nx, Ny : int
+        Number of Yee cells along x and y.  ``Ny`` defaults to ``Nx``.
+    background_er, background_ur : float
+        Permittivity and permeability that fill the unit cell before any
+        user objects are added.
+    boundary_conditions : tuple[int, int]
+        Boundary conditions handed to :func:`yeeder2d`.  ``1`` denotes
+        periodic boundaries, ``0`` would use Dirichlet walls.
+    """
 
-# RECIPROCAL LATTICE VECTORS
-T1 = (2 * np.pi / a) * np.array([[1], [0]])
-T2 = (2 * np.pi / a) * np.array([[0], [1]])
+    def __init__(
+        self,
+        a: float,
+        Nx: int,
+        Ny: int | None = None,
+        *,
+        background_er: float = 1.0,
+        background_ur: float = 1.0,
+        boundary_conditions: tuple[int, int] = (1, 1),
+    ) -> None:
+        self.a = float(a)
+        self.Nx = int(Nx)
+        self.Ny = int(Ny) if Ny is not None else int(Nx)
+        self.boundary_conditions = tuple(boundary_conditions)
 
-# KEY POINTS OF SYMMETRY
-G = np.array([[0], [0]])
-X = 0.5 * T1
-M = 0.5 * T1 + 0.5 * T2
+        # Spatial resolution and double-resolution (2×) Yee helper grid
+        self.dx = self.a / self.Nx
+        self.dy = self.a / self.Ny
+        self.Nx2 = 2 * self.Nx
+        self.Ny2 = 2 * self.Ny
+        self.dx2 = self.dx / 2
+        self.dy2 = self.dy / 2
 
-# CHOOSE PATH AROUND IBZ
-KP = np.hstack((G, X, M, G))
-KL = ['Γ', 'X', 'M', 'Γ']
+        xa2 = np.arange(1, self.Nx2 + 1) * self.dx2
+        ya2 = np.arange(1, self.Ny2 + 1) * self.dy2
+        self.xa2 = xa2 - np.mean(xa2)
+        self.ya2 = ya2 - np.mean(ya2)
+        self.X2, self.Y2 = np.meshgrid(self.xa2, self.ya2, indexing="xy")
 
-# DETERMINE LENGTH OF IBZ PERIMETER
-NKP = KP.shape[1]
-LIBZ = 0
+        # Material maps on the double-resolution grid
+        self.ER2 = np.full((self.Nx2, self.Ny2), background_er, dtype=complex)
+        self.UR2 = np.full((self.Nx2, self.Ny2), background_ur, dtype=complex)
 
-for m in range(NKP - 1):
-    LIBZ += np.linalg.norm(KP[:, m + 1] - KP[:, m])
+        self._beta_path: np.ndarray | None = None
+        self._results: BandStructureResult | None = None
 
-# GENERATE LIST OF POINTS AROUND IBZ
-dibz = LIBZ / NBETA
-BETA = KP[:, [0]].copy()
-KT = [1]
-NBETA = 1
+    # ------------------------------------------------------------------
+    # Geometry helpers
+    # ------------------------------------------------------------------
+    def add_object(
+        self,
+        mask: MaskLike,
+        *,
+        er: complex | float | np.ndarray | None = None,
+        ur: complex | float | np.ndarray | None = None,
+    ) -> None:
+        """Insert an object into the unit cell.
 
-for m in range(NKP - 1):
-    dK = KP[:, m + 1] - KP[:, m]
-    N = int(np.ceil(np.linalg.norm(dK) / dibz))
-    points = KP[:, m].reshape(-1, 1) + np.outer(dK, np.arange(1, N + 1)) / N
-    BETA = np.hstack((BETA, points))
-    NBETA += N
-    KT.append(NBETA)
+        Parameters
+        ----------
+        mask : array-like or callable
+            Either a boolean array defined on the 2× Yee helper grid or a
+            callable ``f(X, Y)`` returning such an array.  The helper grid
+            coordinates ``X`` and ``Y`` are accessible through the
+            :attr:`X2` and :attr:`Y2` attributes.
+        er, ur : scalar or array, optional
+            Relative permittivity/permeability assigned to cells selected
+            by ``mask``.  If ``None`` the respective property is left
+            untouched.  Scalars broadcast across the mask; arrays must have
+            the same shape as the helper grid.
+        """
 
-# PERFORM FDFD ANALYSIS
-ERxx_diag = diags(ERxx.flatten(order='F'))
-ERyy_diag = diags(ERyy.flatten(order='F'))
-ERzz_diag = diags(ERzz.flatten(order='F'))
-URxx_diag = diags(URxx.flatten(order='F'))
-URyy_diag = diags(URyy.flatten(order='F'))
-URzz_diag = diags(URzz.flatten(order='F'))
+        selection = self._resolve_mask(mask)
+        if not selection.shape == self.ER2.shape:
+            raise ValueError("Mask must match the helper grid shape (2× resolution).")
 
-# INITIALIZE BAND DATA
-WNTE = np.zeros((NBANDS, NBETA), dtype='complex')
-WNTM = np.zeros((NBANDS, NBETA), dtype='complex')
+        if er is not None:
+            er_array = np.asarray(er, dtype=complex)
+            if er_array.shape not in ((), selection.shape):
+                raise ValueError("er must be a scalar or have the same shape as the mask.")
+            self.ER2 = np.where(selection, er_array, self.ER2)
 
-# MAIN LOOP -- ITERATE OVER IBZ
-for nbeta in range(NBETA):
-    # Get Next Bloch Wave Vector
-    beta = BETA[:, nbeta]
+        if ur is not None:
+            ur_array = np.asarray(ur, dtype=complex)
+            if ur_array.shape not in ((), selection.shape):
+                raise ValueError("ur must be a scalar or have the same shape as the mask.")
+            self.UR2 = np.where(selection, ur_array, self.UR2)
 
-    # Build Derivative Matrices
-    NS = [Nx, Ny]
-    RES = [dx, dy]
-    BC = [1, 1]
-    DEX, DEY, DHX, DHY = yeeder2d(NS, RES, BC, beta)
+    def add_circular_inclusion(
+        self,
+        radius: float,
+        *,
+        center: tuple[float, float] = (0.0, 0.0),
+        er: complex | float | None = None,
+        ur: complex | float | None = None,
+    ) -> None:
+        """Convenience wrapper that inserts a circular inclusion."""
 
-    # TM Mode Analysis
-    A = -DHX @ URyy_diag.power(-1) @ DEX - DHY @ URxx_diag.power(-1) @ DEY
-    B = ERzz_diag
-    D = eigs(A, M=B, k=NBANDS, sigma=0)[0]
-    D = np.sort(D)
-    WNTM[:, nbeta] = D[:NBANDS]
+        cx, cy = center
+        mask = (self.X2 - cx) ** 2 + (self.Y2 - cy) ** 2 <= radius ** 2
+        self.add_object(mask, er=er, ur=ur)
 
-    # TE Mode Analysis
-    A = -DEX @ ERyy_diag.power(-1) @ DHX - DEY @ ERxx_diag.power(-1) @ DHY
-    B = URzz_diag
-    D = eigs(A, M=B, k=NBANDS, sigma=0)[0]
-    D = np.sort(D)
-    WNTE[:, nbeta] = D[:NBANDS]
+    def _resolve_mask(self, mask: MaskLike) -> np.ndarray:
+        if callable(mask):
+            selection = mask(self.X2, self.Y2)
+        else:
+            selection = mask
+        selection = np.asarray(selection, dtype=bool)
+        return selection
 
-# NORMALIZE THE FREQUENCIES
-WNTE = a / (2 * np.pi) * np.real(np.sqrt(WNTE))
-WNTM = a / (2 * np.pi) * np.real(np.sqrt(WNTM))
+    # ------------------------------------------------------------------
+    # Bloch-path utilities
+    # ------------------------------------------------------------------
+    def default_high_symmetry_path(self) -> tuple[list[np.ndarray], list[str]]:
+        """Return the Γ–X–M–Γ path for a square lattice."""
 
-# PLOT
-fig = plt.figure(constrained_layout=True)
-gs = gridspec.GridSpec(6, 8, figure=fig)
-ax1 = fig.add_subplot(gs[0:3, 0:3])
-ax2 = fig.add_subplot(gs[3:6, 0:3])
-ax3 = fig.add_subplot(gs[:, 3:])
+        T1 = (2 * np.pi / self.a) * np.array([1.0, 0.0])
+        T2 = (2 * np.pi / self.a) * np.array([0.0, 1.0])
 
-im = ax1.imshow(ER2.T, extent=(xa2.min(), xa2.max(), ya2.min(), ya2.max()), origin='lower', cmap='viridis')
-ax1.set_title('Unit Cell')
-cbar = fig.colorbar(im, ax=ax1)  # Add a colorbar to ax1
-cbar.set_label('$\\epsilon_r$')
+        gamma = np.array([0.0, 0.0])
+        x_point = 0.5 * T1
+        m_point = 0.5 * (T1 + T2)
 
-image = mpimg.imread('2D_Band_Diagram_Illustration.png')  # Replace with your image file path
-ax2.imshow(image)
-ax2.axis('off')
+        points = [gamma, x_point, m_point, gamma]
+        labels = ["Γ", "X", "M", "Γ"]
+        return points, labels
 
-ax3.plot(range(1, NBETA + 1), WNTM.T, '.b', label='TM')
-ax3.plot(range(1, NBETA + 1), WNTE.T, '.r', label='TE')
-handles, labels = ax3.get_legend_handles_labels()
-unique_labels = dict(zip(labels, handles))
-ax3.legend(unique_labels.values(), unique_labels.keys())
-ax3.set_xlim([1, NBETA])
-ax3.set_ylim([0, wnmax])
-ax3.set_xticks(KT)
-ax3.set_xticklabels(KL)
-ax3.set_xlabel('Bloch Wave Vector $\\vec{\\beta}$')
-ax3.set_ylabel('Frequency $\\omega_{n} = a/\\lambda_0$')
-ax3.set_title('Photonic Band Diagram')
-plt.show()
+    def generate_bloch_path(
+        self,
+        symmetry_points: Sequence[Sequence[float]],
+        total_points: int,
+    ) -> tuple[np.ndarray, list[int]]:
+        """Sample a polyline connecting the supplied symmetry points."""
+
+        if total_points < len(symmetry_points):
+            raise ValueError("total_points must be at least the number of symmetry points.")
+
+        pts = np.asarray(symmetry_points, dtype=float)
+        if pts.ndim != 2 or pts.shape[1] != 2:
+            raise ValueError("symmetry_points must be an iterable of 2D coordinates.")
+
+        segment_lengths = np.linalg.norm(np.diff(pts, axis=0), axis=1)
+        total_length = segment_lengths.sum()
+        if total_length == 0:
+            # Degenerate case – distribute points uniformly
+            segment_lengths = np.ones_like(segment_lengths)
+            total_length = segment_lengths.sum()
+
+        # Determine how many interpolation points to allocate to each segment
+        points_remaining = total_points - 1  # first point already counted
+        counts = []
+        for length in segment_lengths:
+            weight = length / total_length
+            counts.append(max(1, int(round(points_remaining * weight))))
+
+        # Adjust counts so that the total matches points_remaining
+        diff = points_remaining - sum(counts)
+        idx = 0
+        while diff != 0 and counts:
+            if diff > 0:
+                counts[idx % len(counts)] += 1
+                diff -= 1
+            elif counts[idx % len(counts)] > 1:
+                counts[idx % len(counts)] -= 1
+                diff += 1
+            idx += 1
+
+        betas = [pts[0]]
+        tick_positions = [0]
+        accumulated = 0
+
+        for seg_idx, (start, stop, n_seg) in enumerate(zip(pts[:-1], pts[1:], counts)):
+            for step in range(1, n_seg + 1):
+                t = step / n_seg
+                betas.append(start + t * (stop - start))
+            accumulated += n_seg
+            tick_positions.append(accumulated)
+
+        beta_path = np.column_stack(betas)
+        self._beta_path = beta_path
+        self._tick_positions = list(tick_positions)
+        return beta_path, tick_positions
+
+    # ------------------------------------------------------------------
+    # Solver core
+    # ------------------------------------------------------------------
+    def compute_band_structure(
+        self,
+        beta_path: np.ndarray,
+        *,
+        num_bands: int,
+        polarisations: Iterable[str] = ("TE", "TM"),
+        eig_sigma: float = 0.0,
+    ) -> BandStructureResult:
+        """Solve for the requested polarisations along ``beta_path``."""
+
+        polarisations = tuple(pol.upper() for pol in polarisations)
+        allowed = {"TE", "TM"}
+        if any(pol not in allowed for pol in polarisations):
+            raise ValueError(f"polarisations must be drawn from {allowed}.")
+
+        if beta_path.shape[0] != 2:
+            raise ValueError("beta_path must be a 2×N array of Bloch vectors.")
+
+        num_samples = beta_path.shape[1]
+        frequencies: dict[str, np.ndarray] = {}
+        eigenvalues: dict[str, np.ndarray] = {}
+
+        tensors = self._yee_tensors()
+        ERxx = tensors["ERxx"]
+        ERyy = tensors["ERyy"]
+        ERzz = tensors["ERzz"]
+        URxx = tensors["URxx"]
+        URyy = tensors["URyy"]
+        URzz = tensors["URzz"]
+
+        ERxx_diag = diags(ERxx.flatten(order="F"))
+        ERyy_diag = diags(ERyy.flatten(order="F"))
+        ERzz_diag = diags(ERzz.flatten(order="F"))
+        URxx_diag = diags(URxx.flatten(order="F"))
+        URyy_diag = diags(URyy.flatten(order="F"))
+        URzz_diag = diags(URzz.flatten(order="F"))
+
+        URxx_inv = URxx_diag.power(-1)
+        URyy_inv = URyy_diag.power(-1)
+        ERxx_inv = ERxx_diag.power(-1)
+        ERyy_inv = ERyy_diag.power(-1)
+
+        for pol in polarisations:
+            frequencies[pol] = np.zeros((num_bands, num_samples), dtype=float)
+            eigenvalues[pol] = np.zeros((num_bands, num_samples), dtype=complex)
+
+        for idx in range(num_samples):
+            beta = beta_path[:, idx]
+            DEX, DEY, DHX, DHY = yeeder2d(
+                [self.Nx, self.Ny],
+                [self.dx, self.dy],
+                list(self.boundary_conditions),
+                beta,
+            )
+
+            if "TM" in polarisations:
+                A_tm = -DHX @ URyy_inv @ DEX - DHY @ URxx_inv @ DEY
+                vals_tm = eigs(A_tm, M=ERzz_diag, k=num_bands, sigma=eig_sigma)[0]
+                eig_tm = self._sort_eigenvalues(vals_tm, num_bands)
+                eigenvalues["TM"][:, idx] = eig_tm
+                frequencies["TM"][:, idx] = self._normalise_eigenvalues(eig_tm)
+
+            if "TE" in polarisations:
+                A_te = -DEX @ ERyy_inv @ DHX - DEY @ ERxx_inv @ DHY
+                vals_te = eigs(A_te, M=URzz_diag, k=num_bands, sigma=eig_sigma)[0]
+                eig_te = self._sort_eigenvalues(vals_te, num_bands)
+                eigenvalues["TE"][:, idx] = eig_te
+                frequencies["TE"][:, idx] = self._normalise_eigenvalues(eig_te)
+
+        tick_positions = self._tick_positions_from_path(beta_path)
+        tick_labels = getattr(self, "_tick_labels", []) or [""] * len(tick_positions)
+
+        result = BandStructureResult(
+            beta_path=beta_path,
+            tick_positions=tick_positions,
+            tick_labels=tick_labels,
+            frequencies=frequencies,
+            eigenvalues=eigenvalues,
+        )
+        self._results = result
+        return result
+
+    def _tick_positions_from_path(self, beta_path: np.ndarray) -> list[int]:
+        if self._beta_path is None or not np.array_equal(beta_path, self._beta_path):
+            return list(range(beta_path.shape[1]))
+        # _beta_path is built alongside tick positions in generate_bloch_path
+        if hasattr(self, "_tick_positions"):
+            return list(self._tick_positions)
+        return list(range(beta_path.shape[1]))
+
+    def set_tick_labels(self, labels: Sequence[str], positions: Sequence[int]) -> None:
+        """Attach labels to the symmetry points in the Brillouin zone path."""
+
+        if len(labels) != len(positions):
+            raise ValueError("labels and positions must have the same length.")
+        self._tick_labels = list(labels)
+        self._tick_positions = list(positions)
+
+    # ------------------------------------------------------------------
+    # Plotting
+    # ------------------------------------------------------------------
+    def plot_band_diagram(
+        self,
+        result: BandStructureResult,
+        *,
+        wnmax: float | None = None,
+        path_artist_kwargs: dict[str, Any] | None = None,
+    ) -> tuple[Figure, tuple[Axes, Axes, Axes]]:
+        """Create the unit-cell, Bloch-path and band-diagram figure.
+
+        Parameters
+        ----------
+        result : BandStructureResult
+            Output from :meth:`compute_band_structure`.
+        wnmax : float, optional
+            Upper limit for the normalised frequency axis.
+        path_artist_kwargs : dict, optional
+            Extra keyword arguments forwarded to
+            :meth:`matplotlib.axes.Axes.plot` when drawing the Bloch path.
+        """
+
+        beta_count = result.beta_path.shape[1]
+        x_axis = np.arange(beta_count)
+
+        fig = plt.figure(constrained_layout=True)
+        gs = gridspec.GridSpec(6, 8, figure=fig)
+        ax_structure = fig.add_subplot(gs[0:3, 0:3])
+        ax_path = fig.add_subplot(gs[3:6, 0:3])
+        ax_bands = fig.add_subplot(gs[:, 3:])
+
+        structure_map = np.real_if_close(self.ER2)
+        if np.iscomplexobj(structure_map):
+            structure_map = np.abs(structure_map)
+
+        im = ax_structure.imshow(
+            np.asarray(structure_map, dtype=float).T,
+            extent=(self.xa2.min(), self.xa2.max(), self.ya2.min(), self.ya2.max()),
+            origin="lower",
+            cmap="viridis",
+        )
+        ax_structure.set_title("Unit Cell")
+        cbar = fig.colorbar(im, ax=ax_structure)
+        cbar.set_label(r"$\epsilon_r$")
+
+        self._draw_bloch_path_panel(ax_path, result, path_artist_kwargs)
+
+        for pol, style in (("TM", "b"), ("TE", "r")):
+            if pol in result.frequencies:
+                ax_bands.plot(
+                    x_axis,
+                    result.frequencies[pol].T,
+                    f".{style}",
+                    label=pol,
+                )
+
+        handles, labels = ax_bands.get_legend_handles_labels()
+        if handles:
+            unique = dict(zip(labels, handles))
+            ax_bands.legend(unique.values(), unique.keys())
+
+        ticks = result.tick_positions
+        labels = result.tick_labels if any(result.tick_labels) else [""] * len(ticks)
+        ax_bands.set_xticks(ticks)
+        ax_bands.set_xticklabels(labels)
+        ax_bands.set_xlim([0, beta_count - 1])
+        if wnmax is not None:
+            ax_bands.set_ylim([0, wnmax])
+        ax_bands.set_xlabel(r"Bloch wave vector $\vec{\beta}$")
+        ax_bands.set_ylabel(r"Normalised frequency $a / \lambda_0$")
+        ax_bands.set_title("Photonic Band Diagram")
+
+        return fig, (ax_structure, ax_path, ax_bands)
+
+    def _draw_bloch_path_panel(
+        self,
+        ax: Axes,
+        result: BandStructureResult,
+        path_artist_kwargs: dict[str, Any] | None,
+    ) -> None:
+        """Render the sampled Bloch path in reciprocal space."""
+
+        beta_path = result.beta_path
+        if beta_path.size == 0:
+            ax.axis("off")
+            return
+
+        default_kwargs: dict[str, Any] = {
+            "color": "tab:blue",
+            "linewidth": 1.5,
+        }
+        if path_artist_kwargs:
+            default_kwargs.update(path_artist_kwargs)
+
+        ax.plot(beta_path[0], beta_path[1], **default_kwargs)
+        ax.scatter(
+            beta_path[0],
+            beta_path[1],
+            s=10,
+            color=default_kwargs.get("color", "tab:blue"),
+            alpha=0.3,
+        )
+
+        ticks = result.tick_positions
+        labels = result.tick_labels if any(result.tick_labels) else [""] * len(ticks)
+
+        for label, idx in zip(labels, ticks):
+            if idx >= beta_path.shape[1]:
+                continue
+            bx, by = beta_path[:, idx]
+            ax.scatter(bx, by, s=30, color="black", zorder=3)
+            if label:
+                ax.annotate(
+                    label,
+                    xy=(bx, by),
+                    xytext=(6, 6),
+                    textcoords="offset points",
+                    fontsize=9,
+                    weight="bold",
+                )
+
+        g = np.pi / self.a
+        square = np.array([
+            [-g, -g],
+            [g, -g],
+            [g, g],
+            [-g, g],
+            [-g, -g],
+        ])
+        ax.plot(
+            square[:, 0],
+            square[:, 1],
+            linestyle="--",
+            linewidth=1.0,
+            color="0.5",
+            label="1st BZ",
+        )
+
+        if "1st BZ" not in [text.get_text() for text in ax.texts]:
+            ax.text(
+                g,
+                g,
+                "1st BZ",
+                ha="right",
+                va="bottom",
+                fontsize=8,
+                color="0.4",
+            )
+
+        x_vals = beta_path[0]
+        y_vals = beta_path[1]
+        x_min, x_max = float(np.min(x_vals)), float(np.max(x_vals))
+        y_min, y_max = float(np.min(y_vals)), float(np.max(y_vals))
+        x_span = x_max - x_min
+        y_span = y_max - y_min
+        x_pad = 0.05 * x_span if x_span else max(abs(x_max), 1.0) * 0.05
+        y_pad = 0.05 * y_span if y_span else max(abs(y_max), 1.0) * 0.05
+
+        ax.set_xlim(x_min - x_pad, x_max + x_pad)
+        ax.set_ylim(y_min - y_pad, y_max + y_pad)
+        ax.set_aspect("equal", adjustable="box")
+        ax.grid(True, linestyle=":", linewidth=0.5)
+        ax.set_xlabel(r"$\beta_x$ (rad/m)")
+        ax.set_ylabel(r"$\beta_y$ (rad/m)")
+        ax.set_title("Bloch Path")
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _yee_tensors(self) -> dict[str, np.ndarray]:
+        ERxx = self.ER2[1::2, ::2]
+        ERyy = self.ER2[::2, 1::2]
+        ERzz = self.ER2[::2, 1::2]
+        URxx = self.UR2[1::2, ::2]
+        URyy = self.UR2[::2, 1::2]
+        URzz = self.UR2[::2, 1::2]
+        return {
+            "ERxx": ERxx,
+            "ERyy": ERyy,
+            "ERzz": ERzz,
+            "URxx": URxx,
+            "URyy": URyy,
+            "URzz": URzz,
+        }
+
+    def _sort_eigenvalues(self, values: np.ndarray, num_bands: int) -> np.ndarray:
+        real_parts = np.real(values)
+        order = np.argsort(real_parts)
+        return values[order][:num_bands]
+
+    def _normalise_eigenvalues(self, values: np.ndarray) -> np.ndarray:
+        vals = np.real_if_close(values)
+        vals = np.clip(vals.real, 0.0, None)
+        return self.a / (2 * np.pi) * np.sqrt(vals)
+
+
+def _example() -> None:
+    """Executable example mirroring the original script."""
+
+    solver = BandDiagramSolver2D(a=1.0, Nx=40, background_er=10.2)
+    solver.add_circular_inclusion(radius=0.4, er=1.0)
+
+    points, labels = solver.default_high_symmetry_path()
+    beta_path, tick_positions = solver.generate_bloch_path(points, total_points=200)
+    solver.set_tick_labels(labels, tick_positions)
+
+    result = solver.compute_band_structure(beta_path, num_bands=5)
+    fig, axes = solver.plot_band_diagram(result, wnmax=0.6)
+    axes[1].set_title("Bloch Path: Γ–X–M–Γ")
+    plt.show()
+
+
+if __name__ == "__main__":
+    _example()

--- a/Band_Diagram_Solver/example_square_lattice.py
+++ b/Band_Diagram_Solver/example_square_lattice.py
@@ -1,0 +1,167 @@
+"""Example usage of :class:`BandDiagramSolver2D` with multiple Bloch paths."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Sequence
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+MODULE_NAME = "band_diagram_solver_2d"
+MODULE_PATH = Path(__file__).with_name("2D_Band_Diagram.py")
+_spec = importlib.util.spec_from_file_location(MODULE_NAME, MODULE_PATH)
+if _spec is None or _spec.loader is None:
+    raise ImportError(f"Unable to load 2D band diagram solver from {MODULE_PATH}")
+_module = importlib.util.module_from_spec(_spec)
+sys.modules[MODULE_NAME] = _module
+_spec.loader.exec_module(_module)
+BandDiagramSolver2D = _module.BandDiagramSolver2D
+
+
+def build_solver() -> "BandDiagramSolver2D":
+    """Construct the dielectric rod lattice used in both examples."""
+
+    solver = BandDiagramSolver2D(a=1.0, Nx=40, background_er=10.2)
+    solver.add_circular_inclusion(radius=0.4, er=1.0)
+    return solver
+
+
+def _solve_with_solver(
+    solver: "BandDiagramSolver2D",
+    symmetry_points: Sequence[Sequence[float]],
+    labels: Sequence[str],
+    *,
+    total_points: int,
+    num_bands: int,
+    wnmax: float,
+    path_title: str,
+):
+    """Drive the solver along ``symmetry_points`` and plot the band diagram."""
+
+    beta_path, tick_positions = solver.generate_bloch_path(
+        symmetry_points, total_points=total_points
+    )
+    solver.set_tick_labels(labels, tick_positions)
+
+    result = solver.compute_band_structure(beta_path, num_bands=num_bands)
+    fig, (ax_structure, ax_path, ax_bands) = solver.plot_band_diagram(
+        result, wnmax=wnmax
+    )
+    ax_path.set_title(f"Bloch Path ({path_title})")
+    return fig
+
+
+def solve_default_path_example(*, total_points: int, num_bands: int, wnmax: float):
+    """Run the canonical Γ–X–M–Γ sweep for a square lattice."""
+
+    solver = build_solver()
+    points, labels = solver.default_high_symmetry_path()
+    return _solve_with_solver(
+        solver,
+        points,
+        labels,
+        total_points=total_points,
+        num_bands=num_bands,
+        wnmax=wnmax,
+        path_title="Γ–X–M–Γ",
+    )
+
+
+def solve_custom_path_example(*, total_points: int, num_bands: int, wnmax: float):
+    """Demonstrate a user-defined Bloch path through the first Brillouin zone."""
+
+    solver = build_solver()
+    g = 2 * np.pi / solver.a
+    gamma = np.array([0.0, 0.0])
+    q_point = np.array([0.45 * g, 0.10 * g])
+    r_point = np.array([0.60 * g, 0.65 * g])
+    s_point = np.array([0.10 * g, 0.90 * g])
+    points = [gamma, q_point, r_point, s_point, gamma]
+    labels = ["Γ", "Q", "R", "S", "Γ"]
+
+    return _solve_with_solver(
+        solver,
+        points,
+        labels,
+        total_points=total_points,
+        num_bands=num_bands,
+        wnmax=wnmax,
+        path_title="Γ–Q–R–S–Γ",
+    )
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments for the example script."""
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "Solve and plot photonic band diagrams for a dielectric rod lattice "
+            "using the BandDiagramSolver2D class. Choose between the default "
+            "Γ–X–M–Γ path or a custom user-defined sweep."
+        )
+    )
+    parser.add_argument(
+        "--path",
+        choices=("default", "custom", "both"),
+        default="default",
+        help="Which Bloch path example to run (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--points",
+        type=int,
+        default=200,
+        help=(
+            "Number of β samples along each sweep when generating the Bloch path "
+            "(default: %(default)s)."
+        ),
+    )
+    parser.add_argument(
+        "--num-bands",
+        type=int,
+        default=5,
+        help="How many bands to compute for each polarisation (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--wnmax",
+        type=float,
+        default=0.6,
+        help="Upper limit for the normalised frequency axis (default: %(default)s).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    """Execute the requested band diagram example(s)."""
+
+    args = parse_args(argv)
+
+    figures = []
+    if args.path in {"default", "both"}:
+        figures.append(
+            solve_default_path_example(
+                total_points=args.points,
+                num_bands=args.num_bands,
+                wnmax=args.wnmax,
+            )
+        )
+
+    if args.path in {"custom", "both"}:
+        figures.append(
+            solve_custom_path_example(
+                total_points=args.points,
+                num_bands=args.num_bands,
+                wnmax=args.wnmax,
+            )
+        )
+
+    if figures:
+        plt.show()
+
+
+if __name__ == "__main__":
+    main()
+

--- a/README.md
+++ b/README.md
@@ -1,46 +1,166 @@
-# FDFD\_CEM
+# FDFD_CEM
 
-This repository contains a beginner-friendly suite of **Finite-Difference Frequency-Domain (FDFD)** solvers for computational electromagnetics. The solvers are modularly organized by application area—covering mode analysis, band diagram computation, scattering, and electrostatics.
+Beginner-friendly **Finite-Difference Frequency-Domain (FDFD)** solvers for
+computational electromagnetics.  Every solver follows the same pattern:
+create a Yee grid, assign material distributions, apply boundary
+conditions and solve sparse eigenvalue problems for the desired field
+components.  The repository is organised by application area so you can
+jump directly to the solver that matches your problem.
 
-## 📁 Repository Structure
+## 📁 Repository map
 
-* `Band_Diagram_Solver`: FDFD-based solver for computing band diagrams of 2D photonic crystals.
-  *(Preliminary and not yet class-structured)*
+### Waveguide & cavity mode solvers
 
-* `Electrostatic_Solver`: Solves electrostatic field distributions in 1D and 2D.
-  *(Note: strictly speaking, this is not FDFD-based)*
+| Folder | Description |
+| --- | --- |
+| `Mode_Solver_1D/` | 1‑D slab waveguide eigen-mode solver with anisotropic materials, impedance sheets and uniaxial PML.  Main entry point: [`FDFD_1D_Mode_Solver.py`](Mode_Solver_1D/FDFD_1D_Mode_Solver.py). |
+| `Mode_Solver_2D/` | 2‑D cross-section mode solver for structures that are uniform along the propagation axis.  Supports anisotropy, impedance sheets and UPML.  Main entry point: [`FDFD_Mode_Solver.py`](Mode_Solver_2D/FDFD_Mode_Solver.py). |
+| `Periodic_2D/` | FDFD solver for 2‑D periodic waveguides (e.g. leaky-wave antennas).  Periodicity is enforced along *z*; materials may vary along *x* and *z*. |
+| `Periodic_3D/` | 3‑D periodic mode solver with Bloch-periodic boundary conditions along *z* and full-vector fields. |
 
-* `Mode_Solver_1D`: FDFD mode solver for 1D slab waveguides.
-  *Supports anisotropic materials and impedance surfaces.*
+### Photonic crystal analysis
 
-* `Mode_Solver_2D`: FDFD mode solver for 2D waveguides (structures homogeneous along the propagation direction).
-  *Supports anisotropic materials, impedance surfaces, and PML boundaries.*
+| Folder | Description |
+| --- | --- |
+| `Band_Diagram_Solver/` | Contains the new class-based band diagram engine [`2D_Band_Diagram.py`](Band_Diagram_Solver/2D_Band_Diagram.py).  Users can compose a unit cell by adding objects, sweep Bloch wave vectors and visualise TE/TM photonic bands. |
 
-* `Mode_Solver_Periodic`: FDFD solver for periodic waveguide structures, including leaky-wave antennas.
-  *Supports anisotropic materials and PML.*
+### Other solvers and utilities
 
-* `Scattering`: 2D FDFD TM/TE solver for electromagnetic scattering problems using the QAAQ formulation.
-  *Supports anisotropic materials and PML.*
-
-* `Mesh_points_calculation.py`: Utility for generating spatial mesh grid points for the simulation domain.
-
-* `PML_sigma_calculation.py`: Utility for computing sigma (conductivity) profiles in perfectly matched layers (PML).
+| Folder / File | Purpose |
+| --- | --- |
+| `Scattering/` | 2‑D TE/TM scattering solver formulated with the QAAQ matrix approach. |
+| `Electrostatic_Solver/` | Electrostatic field solvers in 1‑D and 2‑D (not FDFD-based but bundled for convenience). |
+| `Mesh_points_calculation.py` | Generates spatial mesh points for arbitrary simulation domains. |
+| `PML_sigma_calculation.py` | Utility for deriving polynomial conductivity profiles used in UPML implementations. |
 
 ---
 
-## 🧠 Modal Analysis Workflow
+## 🧭 Detailed workflows
 
-For modal analysis:
+The following sections explain the end-to-end process for the core mode
+solvers.  Each workflow mirrors the implementation in the corresponding
+Python module so you know exactly which API calls to use.
 
-1. **Create the mesh** using your preferred geometry and resolution.
-2. **Add objects with customized permittivity and permeability** using `solver.add_object()`.
-3. **Apply absorbing boundaries** using `solver.add_UPML()`.
-4. **Solve modes** using `solver.solve()`
-5. **Visualize modal fields** along with their propagation constants (α and β) using: `solver.visualize_with_gui()`
+### 1‑D waveguide modes (`Mode_Solver_1D`)
 
+1. **Instantiate the solver** – create [`FDFDModeSolver`](Mode_Solver_1D/FDFD_1D_Mode_Solver.py)
+   with the operating frequency, spatial span and grid resolution.  The
+   constructor normalises the derivative matrices using the free-space
+   wavenumber and prepares diagonal material tensors.【F:Mode_Solver_1D/FDFD_1D_Mode_Solver.py†L9-L61】
+2. **Define materials** – call `add_object()` to assign permittivity and
+   permeability to slices of the slab.  Scalars or length-3 tuples (xx,
+   yy, zz) allow isotropic or diagonal-anisotropic regions.  Surface
+   impedance sheets can be inserted with `add_impedance_surface()` and
+   the balanced update ensures TE/TM loadings remain matched.【F:Mode_Solver_1D/FDFD_1D_Mode_Solver.py†L64-L162】
+3. **Add absorbing boundaries** – `add_UPML()` wraps the domain with
+   uniaxial PML by stretching ε and µ according to the requested
+   conductivity taper.【F:Mode_Solver_1D/FDFD_1D_Mode_Solver.py†L164-L196】
+4. **Solve the eigen-problem** – `solve()` builds sparse diagonal
+   matrices for ε/µ, assembles the TE/TM operators and calls
+   `scipy.sparse.linalg.eigs`.  Propagation constants are the square root
+   of each eigenvalue (γ = α + jβ) and field components are back-solved
+   on the Yee grid.【F:Mode_Solver_1D/FDFD_1D_Mode_Solver.py†L198-L246】
+5. **Inspect the results** – use `visualize_with_gui()` for an interactive
+   plot of Ey/Hx/Hz (TE) and Hy/Ex/Ez (TM) along the waveguide together
+   with α/β readouts.【F:Mode_Solver_1D/FDFD_1D_Mode_Solver.py†L248-L352】
+
+### 2‑D waveguide modes (`Mode_Solver_2D`)
+
+1. **Instantiate the solver** – construct [`FDFDModeSolver`](Mode_Solver_2D/FDFD_Mode_Solver.py)
+   with frequency, cross-section sizes and grid counts.  The class
+   pre-computes Yee-derivative matrices normalised by k₀ and initialises
+   2‑D ε/µ tensors.【F:Mode_Solver_2D/FDFD_Mode_Solver.py†L13-L41】
+2. **Populate the cross-section** – `add_object()` writes isotropic or
+   diagonal-anisotropic rectangles into the permittivity and permeability
+   maps.  Optional helpers add UPML regions (`add_UPML()`) or impedance
+   sheets (`add_impedance_surface()`) aligned with x or y walls.【F:Mode_Solver_2D/FDFD_Mode_Solver.py†L43-L185】
+3. **Solve for modes** – `solve()` block-assembles the P and Q matrices,
+   forms Ω = P·Q and computes the requested number of eigenmodes using a
+   shift-invert strategy.  Electric and magnetic field components are
+   reconstructed by applying the derivative operators and inverse
+   material tensors.【F:Mode_Solver_2D/FDFD_Mode_Solver.py†L187-L230】
+4. **Visualise fields** – `visualize()` or `visualize_with_gui()` reshape
+   the eigenvectors into 2‑D maps, normalise magnitudes and overlay the
+   material profile for context.【F:Mode_Solver_2D/FDFD_Mode_Solver.py†L232-L362】
+
+### 2‑D periodic structures (`Periodic_2D`)
+
+1. **Select the polarisation solver** – instantiate either
+   [`TM_Mode_Solver`](Periodic_2D/Periodic_Mode_Solver.py) to compute the
+   TM field triplet (Hy, Ex, Ez) or [`TE_Mode_Solver`](Periodic_2D/Periodic_Mode_Solver.py)
+   for the complementary TE components (Ey, Hx, Hz).  Both constructors
+   share the same signature (frequency, domain sizes, grid resolution)
+   and build Bloch-periodic derivative operators along *z*.【F:Periodic_2D/Periodic_Mode_Solver.py†L10-L73】【F:Periodic_2D/Periodic_Mode_Solver.py†L204-L287】
+2. **Define the unit cell** – `add_object()` populates regions (slices
+   along *x* and *z*) with scalar or anisotropic permittivity/permeability.
+   Optional `add_UPML()` stretches the coordinates to absorb radiation
+   at the transverse boundaries.【F:Periodic_2D/Periodic_Mode_Solver.py†L75-L129】【F:Periodic_2D/Periodic_Mode_Solver.py†L238-L270】
+3. **Solve the Bloch eigen-problem** – `solve()` assembles the generalised
+   eigen-system A·v = λ·B·v with shift-invert around the supplied guess
+   for the complex propagation constant.  The resulting eigenvalues are
+   normalised by k₀ to yield γ/k₀, whose imaginary part is β and real
+   part is −α.【F:Periodic_2D/Periodic_Mode_Solver.py†L131-L167】【F:Periodic_2D/Periodic_Mode_Solver.py†L272-L306】
+4. **Post-process** – `visualize_with_gui()` reshapes the eigenvectors to
+   display the available field components for the chosen polarisation:
+   |Hy|/|Ex|/|Ez| for TM or |Ey|/|Hx|/|Hz| for TE, overlaid on the
+   permittivity map and annotated with the complex propagation constants.【F:Periodic_2D/Periodic_Mode_Solver.py†L169-L231】【F:Periodic_2D/Periodic_Mode_Solver.py†L308-L380】
+
+### 3‑D periodic structures (`Periodic_3D`)
+
+1. **Initialise the solver** – create [`Periodic_3D_Mode_Solver`](Periodic_3D/Periodic_Mode_Solver_3D.py)
+   with grid dimensions, physical spans and frequency.  The constructor
+   builds Kronecker-product derivative matrices with periodicity along z
+   and allocates 3‑D ε/µ arrays.【F:Periodic_3D/Periodic_Mode_Solver_3D.py†L9-L63】
+2. **Populate materials** – `add_object()` writes scalar or anisotropic
+   permittivity/permeability tensors into cuboidal regions of the unit
+   cell.  `add_UPML()` optionally wraps selected faces with polynomial
+   UPML stretches.【F:Periodic_3D/Periodic_Mode_Solver_3D.py†L65-L123】
+3. **Solve for Bloch modes** – `solve()` constructs the full-vector
+   generalised eigen-problem (A, B) for the four tangential field
+   components, applies shift-invert and divides the eigenvalues by k₀ to
+   obtain the complex propagation constants γ/k₀.【F:Periodic_3D/Periodic_Mode_Solver_3D.py†L125-L178】
+4. **Inspect modal fields** – `store_fields()` reshapes the eigenvectors
+   into volumetric Ex/Ey/Hx/Hy arrays that can be sliced with
+   `plot_field_plane()` for visual analysis.【F:Periodic_3D/Periodic_Mode_Solver_3D.py†L180-L216】
+
+---
+
+## 📊 Photonic band diagrams (`Band_Diagram_Solver`)
+
+[`BandDiagramSolver2D`](Band_Diagram_Solver/2D_Band_Diagram.py) is a
+fully fledged class replacing the previous script-style implementation.
+The workflow mirrors the other solvers:
+
+1. **Instantiate the solver** with the lattice constant and Yee grid size.
+   The constructor creates a 2×-refined helper grid that matches Rumpf's
+   subpixel averaging strategy.【F:Band_Diagram_Solver/2D_Band_Diagram.py†L38-L88】
+2. **Add geometry** using `add_object()` or convenience helpers such as
+   `add_circular_inclusion()`; masks can be arrays or callables of the
+   helper grid coordinates.【F:Band_Diagram_Solver/2D_Band_Diagram.py†L90-L134】
+3. **Define the Bloch path** with `default_high_symmetry_path()` (Γ–X–M–Γ
+   for square lattices) and `generate_bloch_path()`, then optionally set
+   tick labels for the symmetry points.【F:Band_Diagram_Solver/2D_Band_Diagram.py†L142-L204】
+4. **Compute the bands** using `compute_band_structure()`, which extracts
+   the Yee-grid material tensors, builds derivative operators for each
+   Bloch vector and solves the TE/TM sparse eigen-problems.  Eigenvalues
+   are sorted and normalised to `a/λ`.  Results are returned as a
+   `BandStructureResult` dataclass for easy post-processing.【F:Band_Diagram_Solver/2D_Band_Diagram.py†L206-L293】
+5. **Plot the diagram** with `plot_band_diagram()`, which renders the
+   unit cell, overlays the sampled Bloch path directly in reciprocal
+   space, and charts the TE/TM bands.  You can tweak the path styling via
+   the optional ``path_artist_kwargs`` argument.【F:Band_Diagram_Solver/2D_Band_Diagram.py†L311-L406】
+
+A runnable example script,
+[`example_square_lattice.py`](Band_Diagram_Solver/example_square_lattice.py),
+mirrors the dielectric-rod unit-cell calculation and demonstrates how to
+instantiate the solver, sweep the default Γ–X–M–Γ path or a custom
+user-defined route, and plot the resulting TE/TM bands.  Command-line
+flags expose the path selection, β samples, number of bands and plotting
+limits.【F:Band_Diagram_Solver/example_square_lattice.py†L1-L140】
+
+---
 
 ### Reference
-R. Rumpf, Electromagnetic and Photonic Simulation for the Beginner:
-Finite-Difference Frequency-Domain in MATLAB. Artech House, 2022.
 
-
+R. Rumpf, *Electromagnetic and Photonic Simulation for the Beginner:
+Finite-Difference Frequency-Domain in MATLAB*.  Artech House, 2022.


### PR DESCRIPTION
## Summary
- render the Bloch-path panel with Matplotlib inside `plot_band_diagram`, expose optional styling kwargs, and remove the static PNG dependency
- refresh the `_example` helper and the standalone `example_square_lattice.py` script to support both the default Γ–X–M–Γ sweep and a user-defined path via CLI flags
- document the dynamic Bloch-path plotting and new example workflow in the README

## Testing
- python -m compileall Band_Diagram_Solver

------
https://chatgpt.com/codex/tasks/task_e_68ced16d0454832a8e598584d5e6fad1