### PR TITLE
Support rectangular unit cells in band diagram solver

### DIFF
--- a/Band_Diagram_Solver/Band_Diagram.py
+++ b/Band_Diagram_Solver/Band_Diagram.py
@@ -1,11 +1,11 @@
 """Two-dimensional FDFD band diagram solver.
 
-This module now exposes a :class:`BandDiagramSolver2D` that wraps the
-workflow for defining a periodic unit cell, sweeping Bloch wave vectors
-and extracting the photonic band structure.  The API mirrors the style of
-the other solvers in the repository – users can programmatically add
-objects to the Yee grid, request a path through the irreducible Brillouin
-zone and plot the resulting bands.
+This module exposes :class:`BandDiagramSolver2D`, a convenience wrapper for
+defining a periodic **rectangular** unit cell, sweeping Bloch wave vectors and
+extracting the photonic band structure.  The API mirrors the style of the
+other solvers in the repository – users can programmatically add objects to
+the Yee grid, request a path through the irreducible Brillouin zone and plot
+the resulting bands.
 """
 
 from __future__ import annotations
@@ -43,7 +43,7 @@ class BandStructureResult:
     frequencies : dict[str, np.ndarray]
         Dictionary keyed by polarisation ('TE' and/or 'TM').  Each entry is
         an array of shape (num_bands, N) containing the normalised
-        frequencies ``a/λ``.
+        frequencies ``a/λ`` (using the x-period ``a``).
     eigenvalues : dict[str, np.ndarray]
         Un-normalised eigen-values (ω/c)² returned by the eigensolver for
         each polarisation.
@@ -62,9 +62,12 @@ class BandDiagramSolver2D:
     Parameters
     ----------
     a : float
-        Lattice constant of the (square) unit cell.
+        Period of the unit cell along the x direction.
     Nx, Ny : int
         Number of Yee cells along x and y.  ``Ny`` defaults to ``Nx``.
+    b : float, optional
+        Period of the unit cell along the y direction.  Defaults to ``a`` when
+        omitted, preserving the square-lattice behaviour.
     background_er, background_ur : float
         Permittivity and permeability that fill the unit cell before any
         user objects are added.
@@ -79,18 +82,20 @@ class BandDiagramSolver2D:
         Nx: int,
         Ny: int | None = None,
         *,
+        b: float | None = None,
         background_er: float = 1.0,
         background_ur: float = 1.0,
         boundary_conditions: tuple[int, int] = (1, 1),
     ) -> None:
         self.a = float(a)
+        self.b = float(b) if b is not None else float(a)
         self.Nx = int(Nx)
         self.Ny = int(Ny) if Ny is not None else int(Nx)
         self.boundary_conditions = tuple(boundary_conditions)
 
         # Spatial resolution and double-resolution (2×) Yee helper grid
         self.dx = self.a / self.Nx
-        self.dy = self.a / self.Ny
+        self.dy = self.b / self.Ny
         self.Nx2 = 2 * self.Nx
         self.Ny2 = 2 * self.Ny
         self.dx2 = self.dx / 2
@@ -100,7 +105,7 @@ class BandDiagramSolver2D:
         ya2 = np.arange(1, self.Ny2 + 1) * self.dy2
         self.xa2 = xa2 - np.mean(xa2)
         self.ya2 = ya2 - np.mean(ya2)
-        self.X2, self.Y2 = np.meshgrid(self.xa2, self.ya2, indexing="xy")
+        self.X2, self.Y2 = np.meshgrid(self.xa2, self.ya2, indexing="ij")
 
         # Material maps on the double-resolution grid
         self.ER2 = np.full((self.Nx2, self.Ny2), background_er, dtype=complex)
@@ -176,18 +181,19 @@ class BandDiagramSolver2D:
     # ------------------------------------------------------------------
     # Bloch-path utilities
     # ------------------------------------------------------------------
-    def default_square_lattice_path(self) -> tuple[list[np.ndarray], list[str]]:
-        """Return the Γ–X–M–Γ path for a square lattice."""
+    def default_rectangular_lattice_path(self) -> tuple[list[np.ndarray], list[str]]:
+        """Return the Γ–X–M–Y–Γ path for a rectangular lattice."""
 
-        T1 = (2 * np.pi / self.a) * np.array([1.0, 0.0])
-        T2 = (2 * np.pi / self.a) * np.array([0.0, 1.0])
+        gx = 2 * np.pi / self.a
+        gy = 2 * np.pi / self.b
 
         gamma = np.array([0.0, 0.0])
-        x_point = 0.5 * T1
-        m_point = 0.5 * (T1 + T2)
+        x_point = 0.5 * np.array([gx, 0.0])
+        m_point = 0.5 * np.array([gx, gy])
+        y_point = 0.5 * np.array([0.0, gy])
 
-        points = [gamma, x_point, m_point, gamma]
-        labels = ["Γ", "X", "M", "Γ"]
+        points = [gamma, x_point, m_point, y_point, gamma]
+        labels = ["Γ", "X", "M", "Y", "Γ"]
         return points, labels
 
     def generate_bloch_path(
@@ -369,8 +375,12 @@ class BandDiagramSolver2D:
         path_artist_kwargs : dict, optional
             Extra keyword arguments forwarded to
             :meth:`matplotlib.axes.Axes.plot` when drawing the Bloch path.
+        
+        Notes
+        -----
+        The figure is saved to ``band_diagram.png`` and displayed via
+        :func:`matplotlib.pyplot.show` before the axes tuple is returned.
         """
-
 
         beta_count = result.beta_path.shape[1]
         x_axis = np.arange(beta_count)
@@ -427,6 +437,8 @@ class BandDiagramSolver2D:
         ax_bands.set_ylabel(r"Normalised frequency $a / \lambda_0$")
         ax_bands.set_title("Photonic Band Diagram")
 
+        fig.savefig("band_diagram.png", dpi=300, bbox_inches="tight")
+        plt.show()
 
         return fig, (ax_structure, ax_path, ax_bands)
 
@@ -477,17 +489,18 @@ class BandDiagramSolver2D:
                     weight="bold",
                 )
 
-        g = np.pi / self.a
-        square = np.array([
-            [-g, -g],
-            [g, -g],
-            [g, g],
-            [-g, g],
-            [-g, -g],
+        gx = np.pi / self.a
+        gy = np.pi / self.b
+        rectangle = np.array([
+            [-gx, -gy],
+            [gx, -gy],
+            [gx, gy],
+            [-gx, gy],
+            [-gx, -gy],
         ])
         ax.plot(
-            square[:, 0],
-            square[:, 1],
+            rectangle[:, 0],
+            rectangle[:, 1],
             linestyle="--",
             linewidth=1.0,
             color="0.5",
@@ -496,8 +509,8 @@ class BandDiagramSolver2D:
 
         if "1st BZ" not in [text.get_text() for text in ax.texts]:
             ax.text(
-                g,
-                g,
+                gx,
+                gy,
                 "1st BZ",
                 ha="right",
                 va="bottom",

--- a/Band_Diagram_Solver/example_rectangular_unitcell.py
+++ b/Band_Diagram_Solver/example_rectangular_unitcell.py
@@ -1,0 +1,23 @@
+"""Example showing how to work with a rectangular FDFD unit cell."""
+
+import numpy as np
+
+from Band_Diagram import BandDiagramSolver2D
+
+
+solver = BandDiagramSolver2D(a=1.0, b=1.4, Nx=48, Ny=64, background_er=11.9)
+
+# Add a dielectric bar that breaks the four-fold symmetry of the square case.
+def dielectric_bar(X: np.ndarray, Y: np.ndarray) -> np.ndarray:
+    return (np.abs(X) < 0.15) & (Y > -0.2) & (Y < 0.45)
+
+
+solver.add_object(dielectric_bar, er=4.2)
+solver.add_circular_inclusion(radius=0.28, center=(-0.15, 0.0), er=1.0)
+
+points, labels = solver.default_rectangular_lattice_path()
+beta_path, tick_positions = solver.generate_bloch_path(points, total_points=240)
+solver.set_tick_labels(labels, tick_positions)
+
+result = solver.compute_band_structure(beta_path, num_bands=6)
+solver.plot_band_diagram(result, wnmax=0.75)

--- a/Band_Diagram_Solver/example_square_lattice.py
+++ b/Band_Diagram_Solver/example_square_lattice.py
@@ -1,16 +1,12 @@
-from matplotlib import pyplot as plt
-
 from Band_Diagram import BandDiagramSolver2D
 
 solver = BandDiagramSolver2D(a=1.0, Nx=40, background_er=10.2)
 solver.add_circular_inclusion(radius=0.4, er=1.0)
 
-points, labels = solver.default_square_lattice_path()
+points, labels = solver.default_rectangular_lattice_path()
 beta_path, tick_positions = solver.generate_bloch_path(points, total_points=200)
 solver.set_tick_labels(labels, tick_positions)
 
 result = solver.compute_band_structure(beta_path, num_bands=5)
 
-fig, axes = solver.plot_band_diagram(result, wnmax=0.6)
-axes[1].set_title("Bloch Path: Γ–X–M–Γ")
-plt.show()
+solver.plot_band_diagram(result, wnmax=0.6)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ jump directly to the solver that matches your problem.
 
 | Folder | Description |
 | --- | --- |
-| `Band_Diagram_Solver/` | Contains the new class-based band diagram engine [`2D_Band_Diagram.py`](Band_Diagram_Solver/2D_Band_Diagram.py).  Users can compose a unit cell by adding objects, sweep Bloch wave vectors and visualise TE/TM photonic bands. |
+| `Band_Diagram_Solver/` | Contains the class-based band diagram engine [`Band_Diagram.py`](Band_Diagram_Solver/Band_Diagram.py).  Users can compose a rectangular unit cell by adding objects, sweep Bloch wave vectors and visualise TE/TM photonic bands. |
 
 ### Other solvers and utilities
 
@@ -127,39 +127,41 @@ Python module so you know exactly which API calls to use.
 
 ## 📊 Photonic band diagrams (`Band_Diagram_Solver`)
 
-[`BandDiagramSolver2D`](Band_Diagram_Solver/2D_Band_Diagram.py) is a
-fully fledged class replacing the previous script-style implementation.
-The workflow mirrors the other solvers:
+[`BandDiagramSolver2D`](Band_Diagram_Solver/Band_Diagram.py) is a fully
+fledged class replacing the previous script-style implementation.  The
+workflow mirrors the other solvers:
 
-1. **Instantiate the solver** with the lattice constant and Yee grid size.
-   The constructor creates a 2×-refined helper grid that matches Rumpf's
-   subpixel averaging strategy.【F:Band_Diagram_Solver/2D_Band_Diagram.py†L38-L88】
+1. **Instantiate the solver** with the rectangular lattice periods (`a`
+   along x and optional `b` along y) and Yee grid size.  The constructor
+   creates a 2×-refined helper grid that matches Rumpf's subpixel averaging
+   strategy.【F:Band_Diagram_Solver/Band_Diagram.py†L57-L118】
 2. **Add geometry** using `add_object()` or convenience helpers such as
    `add_circular_inclusion()`; masks can be arrays or callables of the
-   helper grid coordinates.【F:Band_Diagram_Solver/2D_Band_Diagram.py†L90-L134】
-3. **Define the Bloch path** with `default_high_symmetry_path()` (Γ–X–M–Γ
-   for square lattices) and `generate_bloch_path()`, then optionally set
-   tick labels for the symmetry points.【F:Band_Diagram_Solver/2D_Band_Diagram.py†L142-L204】
+   helper grid coordinates.【F:Band_Diagram_Solver/Band_Diagram.py†L120-L167】
+3. **Define the Bloch path** with `default_rectangular_lattice_path()`
+   (Γ–X–M–Y–Γ for rectangular cells) and `generate_bloch_path()`, then
+   optionally set tick labels for the symmetry points.【F:Band_Diagram_Solver/Band_Diagram.py†L169-L270】
 4. **Compute the bands** using `compute_band_structure()`, which extracts
    the Yee-grid material tensors, builds derivative operators for each
    Bloch vector and solves the TE/TM sparse eigen-problems.  Eigenvalues
    are sorted and normalised to `a/λ`.  Results are returned as a
-   `BandStructureResult` dataclass for easy post-processing.【F:Band_Diagram_Solver/2D_Band_Diagram.py†L206-L293】
+   `BandStructureResult` dataclass for easy post-processing.【F:Band_Diagram_Solver/Band_Diagram.py†L272-L361】
 
-5. **Plot the diagram** with `plot_band_diagram()`, which renders the
-   unit cell, overlays the sampled Bloch path directly in reciprocal
-   space, and charts the TE/TM bands.  You can tweak the path styling via
-   the optional ``path_artist_kwargs`` argument.【F:Band_Diagram_Solver/2D_Band_Diagram.py†L311-L406】
+5. **Plot the diagram** with `plot_band_diagram()`, which renders the unit
+   cell, overlays the sampled Bloch path directly in reciprocal space,
+   charts the TE/TM bands, saves the figure to `band_diagram.png`, and
+   displays it.  You can tweak the path styling via the optional
+   ``path_artist_kwargs`` argument.【F:Band_Diagram_Solver/Band_Diagram.py†L363-L459】
 
 
-A runnable example script,
-[`example_square_lattice.py`](Band_Diagram_Solver/example_square_lattice.py),
-mirrors the dielectric-rod unit-cell calculation and demonstrates how to
+Example scripts illustrate both square and rectangular settings:
 
-instantiate the solver, sweep the default Γ–X–M–Γ path or a custom
-user-defined route, and plot the resulting TE/TM bands.  Command-line
-flags expose the path selection, β samples, number of bands and plotting
-limits.【F:Band_Diagram_Solver/example_square_lattice.py†L1-L140】
+* [`example_square_lattice.py`](Band_Diagram_Solver/example_square_lattice.py)
+  mirrors the dielectric-rod unit-cell calculation using the default
+  Γ–X–M–Y–Γ path and relies on the automatic plotting behaviour.【F:Band_Diagram_Solver/example_square_lattice.py†L1-L12】
+* [`example_rectangular_unitcell.py`](Band_Diagram_Solver/example_rectangular_unitcell.py)
+  demonstrates an asymmetric rectangular cell that mixes callable masks
+  and the inclusion helper before sweeping the same high-symmetry path.【F:Band_Diagram_Solver/example_rectangular_unitcell.py†L1-L21】
 
 
 ---


### PR DESCRIPTION
## Summary
- extend `BandDiagramSolver2D` to accept independent x/y lattice periods, provide a rectangular high-symmetry path and refresh Bloch-zone plotting
- have `plot_band_diagram` save and show figures automatically while keeping documentation in sync with the new workflow
- refresh the square lattice example and add a dedicated rectangular example script
- fix the double-resolution helper grid orientation so callable masks align with rectangular cells

## Testing
- python -m compileall Band_Diagram_Solver

------
https://chatgpt.com/codex/tasks/task_e_68d006e21238832a8d1834bd9337f808